### PR TITLE
ctapi: Extend functionality with deletion, remote connection.

### DIFF
--- a/ctapi/ctopen.go
+++ b/ctapi/ctopen.go
@@ -19,3 +19,22 @@ func (this *CtApi) CtOpen() (windows.Handle, error) {
 
 	return windows.Handle(r1), nil
 }
+
+func (this *CtApi) CtOpenRemote(sComputer string, sUser string, sPassword string, nMode int) (windows.Handle, error) {
+
+	r1, _, err := this.procs.ctOpen.Call(
+		StringToLPCTSTR(sComputer),
+		StringToLPCTSTR(sUser),
+		StringToLPCTSTR(sPassword),
+		uintptr(nMode))
+
+	if r1 != 0 {
+		return windows.Handle(r1), nil
+	}
+
+	if err != nil {
+		return 0, err
+	}
+
+	return windows.Handle(r1), nil
+}

--- a/ctapi/find.go
+++ b/ctapi/find.go
@@ -60,7 +60,7 @@ func (this *CtApi) FindAll(h windows.Handle, table string) <-chan windows.Handle
 				ch <- hObj
 				hObj, err = this.CtFindNext(hSearch)
 				if err != nil {
-					fmt.Errorf("error geting next", err)
+					fmt.Errorf("error getting next: %v", err)
 				}
 			}
 		}

--- a/ctapi/init.go
+++ b/ctapi/init.go
@@ -25,7 +25,7 @@ func Init(dllName string, dllPath string) (*CtApi, error) {
 
 	r1, _, err := addDllDir.Call(uintptr(unsafe.Pointer(dllPathC)))
 	if r1 == 0 {
-		fmt.Println(os.Stderr, "Unable to add DLL path")
+		fmt.Fprintln(os.Stderr, "Unable to add DLL path")
 		return nil, err
 	}
 

--- a/ctapi/list.go
+++ b/ctapi/list.go
@@ -35,6 +35,16 @@ func (this *CtList) Free() error {
 	return nil
 }
 
+// Delete Frees a tag created with Add (ctListAdd).  Returns true on success,
+// If the function does not succeed, the return value is false.
+func (this *CtList) Delete(hTag windows.Handle) (bool, error) {
+	r1, _, err := this.api.procs.ctListDelete.Call(uintptr(hTag))
+	if r1 == 0 {
+		return false, err
+	}
+	return true, nil
+}
+
 // Add adds a tag to the list of tags being observed.  Returns
 // a handle that can be used to read the item or remove it from
 // the list.  Also returns an error code that is nil if there

--- a/ctapi/list_test.go
+++ b/ctapi/list_test.go
@@ -1,0 +1,114 @@
+package ctapi
+
+import (
+	"fmt"
+	"golang.org/x/sys/windows"
+	"os"
+	"testing"
+)
+
+var tagsToRead = [4]string{"TopMilk_AC01_PV", "TopMilk_AC02_PV", "TopMilk_LS21_PV", "TopMilk_LS07_PV"}
+
+func connectToCitectAPI() (*CtApi, windows.Handle, error) { // Note the addition of error in the return signature
+	var dllPath = os.Getenv("CITECT_DLL_PATH")
+	api, err := Init("CtApi.dll", dllPath)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	ctapiHandle, err := api.CtOpenRemote("localhost",
+		"view",
+		"view",
+		CT_OPEN_READ_ONLY|CT_OPEN_BATCH|CT_OPEN_EXTENDED|CT_OPEN_RECONNECT)
+	fmt.Println(err)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return api, ctapiHandle, nil
+}
+
+func createList(api *CtApi, ctapiHandle windows.Handle) (*CtList, error) {
+	list, err := api.NewList(ctapiHandle)
+	if err != nil {
+		return nil, err
+	}
+	return list, nil
+}
+
+func addTagToList(list *CtList, tag string) (windows.Handle, error) {
+	tagHandle, err := list.Add(tag)
+	if err != nil {
+		fmt.Printf("Failed to add the tag '%s' to the list: %v\n", tag, err)
+		return 0, err
+	}
+	return tagHandle, nil
+}
+
+func removeTagFromList(list *CtList, tag string, tagHandle int) bool {
+	result, err := list.Delete(windows.Handle(tagHandle))
+	if err != nil {
+		fmt.Printf("Failed to remove the tag '%s' to the list: %v\n", tag, err)
+	}
+	return result
+
+}
+
+func TestListAdd(t *testing.T) {
+	api, ctapiHandle, err := connectToCitectAPI()
+	if err != nil {
+		t.Fatalf("Failed to connect to Citect API: %v", err)
+	}
+	defer api.CtClose(ctapiHandle)
+
+	list, err := createList(api, ctapiHandle)
+	if err != nil {
+		t.Fatalf("Failed to create list: %v", err)
+	}
+
+	tagHandles := make(map[string]int)
+
+	for _, tagName := range tagsToRead {
+
+		tagHandle, err := addTagToList(list, tagName)
+		if err != nil {
+			t.Fatalf("Failed to add the tag '%s' to the list: %v\n", tagName, err)
+		} else {
+			fmt.Printf("Tag '%s' to the list: Handle %v\n", tagName, int(tagHandle))
+			tagHandles[tagName] = int(tagHandle)
+		}
+	}
+
+	if err := list.Read(); err != nil {
+		t.Fatalf("Failed to read the list: %v", err)
+	}
+
+	for tagName, tagHandle := range tagHandles {
+		fmt.Println("Reading tag value for", tagName)
+		value, err := list.GetFloatValue(windows.Handle(tagHandle))
+		if err != nil {
+			t.Fatalf("Failed to read the tag '%s' from the list: %v\n", tagName, err)
+			return
+		} else {
+			fmt.Printf("Tag '%s' value: %v\n", tagName, value)
+		}
+	}
+
+	tagToRemove := "TopMilk_AC01_PV"
+
+	removed := removeTagFromList(list, tagToRemove, tagHandles[tagToRemove])
+
+	// Check the tag was removed successfully, it should return true
+	if removed == true {
+		fmt.Printf("Tag removed successfully: %s\n", tagToRemove)
+	} else {
+		t.Fatalf("Failed to remove the tag '%s' from the list\n", tagToRemove)
+	}
+
+	// Check if the tag was removed, this should fail returning 0
+	result, _ := list.GetFloatValue(windows.Handle(tagHandles[tagToRemove]))
+	if result == 0 {
+		fmt.Printf("Tag removed successfully: %s\n", tagToRemove)
+	}
+
+}


### PR DESCRIPTION
- `Delete` | `ctListDelete` function in `list.go`.
- `CtOpenRemote` | `CtOpen` function to enable remote connections, created a new function. (Did not want to break anything you were already using).
- Added `list_test.go` providing tests for connection handling, list operations (creation, addition, reading, and deletion), CITECT_DLL_PATH` environment variable to configure DLL paths for the test file.
- Updated `find.go` and `init.go` to use `fmt.Fprintln` instead of `fmt.Println` for error formatting to comply with Go's standard (GO was complaining about it)
- Tested with Aveva Plant Scada 2023 example project.

Excellent work! I recently started investigating InfluxDB and came upon this project while researching how to create a Telegraf Plugin for the Citect API.